### PR TITLE
avoid warning useNativeDriver

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -18,7 +18,7 @@ export interface CarouselProps {
     autoplay?: boolean;
     autoplayTimeout?: number;
     slipFactor?: number;
-    animation?: (animate: Animated.Value, toValue: number) => Animated.CompositeAnimation;
+    animation?: (animate: Animated.Value, toValue: number, useNativeDriver: true,) => Animated.CompositeAnimation;
     onPageChanged?: (index: number) => void;
     showsPageIndicator?: boolean;
     renderPageIndicator?: (config: PageIndicatorConfig) => JSX.Element;

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -18,7 +18,7 @@ export interface CarouselProps {
     autoplay?: boolean;
     autoplayTimeout?: number;
     slipFactor?: number;
-    animation?: (animate: Animated.Value, toValue: number, useNativeDriver: true,) => Animated.CompositeAnimation;
+    animation?: (animate: Animated.Value, toValue: number, useNativeDriver: false,) => Animated.CompositeAnimation;
     onPageChanged?: (index: number) => void;
     showsPageIndicator?: boolean;
     renderPageIndicator?: (config: PageIndicatorConfig) => JSX.Element;


### PR DESCRIPTION
this change fix the warning display of Animated: 

> `useNativeDriver` was not specified. This is a required 'option and must be explicitly set to `true` or `false`